### PR TITLE
Added support for providing "raw" Graphite configs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,4 +21,9 @@ statsd_flush_counts: true           # send stats_counts metrics
 statsd_graphite:
   legacyNamespace: false
 
+# As an alternative for statsd_graphite variable, you can give "raw" value which get used as is.
+# Handy if you want to use eg. require('os') in the configuration.
+# statsd_graphite_raw: |
+#  { "legacyNamespace": false }
+
 statsd_additional_options: {}       # Setup additional options

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 
-dependencies: [Stouts.nodejs]
+dependencies: []
 
 galaxy_info:
   author: klen

--- a/templates/statsd.js.j2
+++ b/templates/statsd.js.j2
@@ -116,7 +116,12 @@ Optional Variables:
 , flushInterval: {{ statsd_flushInterval|to_nice_json }}
 , percentThreshold: {{ statsd_percentThreshold|to_nice_json }}
 , flush_counts: {{ statsd_flush_counts|to_nice_json }}
+
+{% if statsd_graphite_raw is defined %}
+, graphite: {{ statsd_graphite_raw }}
+{% else %}
 , graphite: {{ statsd_graphite|to_nice_json }}
+{% endif %}
 {% for name, value in statsd_additional_options.items() %}
 , {{name}}: {{value|to_nice_json}}
 {% endfor %}


### PR DESCRIPTION
To be able to use Javascript "require('os')" in the configuration
added new "statsd_graphite_raw" what get passed "as-is" to the
configuration if defined.

Also removed the dependency from the metadata file to not force using that cookbook to install NodeJS.