### PR TITLE
Support installing multiple StatsD daemons on same server

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 
 - name: statsd restart
-  service: name=statsd state=restarted
+  service: name={{statsd_title}} state=restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 
-- name: statsd restart
+- name: "{{statsd_title}} restart"
   service: name={{statsd_title}} state=restarted

--- a/tasks/statsd.yml
+++ b/tasks/statsd.yml
@@ -7,7 +7,7 @@
   npm: name=statsd path={{statsd_home}}
 
 - name: Configure upstart
-  template: src=upstart.conf.j2 dest=/etc/init/statsd.conf
+  template: src=upstart.conf.j2 dest=/etc/init/{{statsd_title}}.conf
   notify:
   - statsd restart
 
@@ -17,4 +17,4 @@
   - statsd restart
 
 - name: Ensure that Statsd is started
-  service: name=statsd state=started enabled=yes
+  service: name={{statsd_title}} state=started enabled=yes

--- a/tasks/statsd.yml
+++ b/tasks/statsd.yml
@@ -9,12 +9,12 @@
 - name: Configure upstart
   template: src=upstart.conf.j2 dest=/etc/init/{{statsd_title}}.conf
   notify:
-  - statsd restart
+  - "{{statsd_title}} restart"
 
 - name: Configure statsd
   template: src=statsd.js.j2 dest={{statsd_home}}/config.js
   notify:
-  - statsd restart
+  - "{{statsd_title}} restart"
 
 - name: Ensure that Statsd is started
   service: name={{statsd_title}} state=started enabled=yes


### PR DESCRIPTION
To make it possible to install StatsD to the same server multiple
times, needed to update init configs to be named based on
custom statsd_title.
From now on by changing statsd_title, port and installation path, you
can install it multiple times on same server.