### PR TITLE
Put nodejs dependency back in

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 
-dependencies: []
+dependencies: ['Stouts.nodejs']
 
 galaxy_info:
   author: klen


### PR DESCRIPTION
Re-adding `nodejs` dependency because:

- It ensures we have `node` installed
- It ensures node is available form the `/usr/bin/node` binary location referenced here
- It ensures we have `npm` installed

I believe Its a fair dependency to have, were there any strong motivations for having removed it in the first place?

Fixes #3 