### PR TITLE
Added possibility to add NPM dependencies

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,6 @@ statsd_graphite:
 #  { "legacyNamespace": false }
 
 statsd_additional_options: {}       # Setup additional options
+
+# Extra NPM dependencies. For example if your config.js depends on to something
+statsd_extra_dependencies: []

--- a/tasks/statsd.yml
+++ b/tasks/statsd.yml
@@ -6,6 +6,10 @@
 - name: Install statsd
   npm: name=statsd path={{statsd_home}}
 
+- name: Install extra NPM dependencies
+  npm: name={{item}} path={{statsd_home}}
+  with_items: statsd_extra_dependencies
+
 - name: Configure upstart
   template: src=upstart.conf.j2 dest=/etc/init/statsd.conf
   notify:


### PR DESCRIPTION
Sometimes you need extra NPM packages, for example in
config.js file. Added new statsd_extra_dependencies variable and
each package in that list get installed before starting statsd.