### PR TITLE
Make sure npm is installed

### DIFF
--- a/tasks/statsd.yml
+++ b/tasks/statsd.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: install npm
+  apt:  pkg=npm state=present update_cache=true
+  
 - name: Prepare Statsd directory
   file: state=directory path={{statsd_home}}
 


### PR DESCRIPTION
The ansible `npm` module needs either the ansible extras package or npm itself in order to work