### PR TITLE
Fix error in init.d script and fix error in Debian version detection.

### DIFF
--- a/tasks/statsd.yml
+++ b/tasks/statsd.yml
@@ -2,7 +2,7 @@
 
 - name: Ensure that NPM is installed
   apt:  name=npm update_cache=yes
-  
+
 - name: Prepare Statsd directory
   file: state=directory path={{statsd_home}}
 
@@ -23,14 +23,14 @@
   - "{{statsd_title}} restart"
 
 - name: Configure sysvinit
-  template: src=sysvinit.conf.j2 dest=/etc/init.d/{{statsd_title}}
-  when: ansible_distribution=="Debian" and ansible_distribution_major_version < 8
+  template: src=sysvinit.j2 dest=/etc/init.d/{{statsd_title}} mode=755
+  when: ansible_distribution=="Debian" and ansible_distribution_major_version|int < 8
   notify:
   - "{{statsd_title}} restart"
 
 - name: Configure systemd
   template: src=systemd.service.j2 dest=/etc/systemd/system/{{statsd_title}}.service
-  when: ansible_distribution=="Debian" and ansible_distribution_major_version > 8
+  when: ansible_distribution=="Debian" and ansible_distribution_major_version|int > 8
   notify:
   - "{{statsd_title}} restart"
 

--- a/templates/sysvinit.j2
+++ b/templates/sysvinit.j2
@@ -21,7 +21,7 @@ fi
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="StatsD"
 NAME={{statsd_title}}
-USER={statsd_user}}
+USER={{statsd_user}}
 DAEMON=$NODE_BIN
 DAEMON_ARGS="{{statsd_home}}/node_modules/statsd/stats.js {{statsd_home}}/config.js"
 PIDFILE=/var/run/$NAME/$NAME.pid
@@ -46,6 +46,12 @@ if [ ! -d /var/run/$NAME ];
 then
   mkdir /var/run/$NAME
   chown $USER /var/run/$NAME
+fi
+# Create log dir on runtime
+if [ ! -d /var/log/$NAME ];
+then
+  mkdir /var/log/$NAME
+  chown $USER /var/log/$NAME
 fi
 
 #


### PR DESCRIPTION
Sorry but my previous PR contained errors : 
- Wrong detection of Debian version, ansible_distribution_major_version must be converted to integer before to compare with 8 number (sysvinit / systemd detection)
- Template sysvinit contain error, missing {
- Changing mode of sysvinit (755)
- In  template sysvinit, creating the log directory if it not exist
