### PR TITLE
Ubuntu >15.04 support & minor bug fixes

### DIFF
--- a/tasks/statsd.yml
+++ b/tasks/statsd.yml
@@ -16,7 +16,7 @@
 
 - name: Install extra NPM dependencies
   npm: name={{item}} path={{statsd_home}}
-  with_items: statsd_extra_dependencies
+  with_items: "{{ statsd_extra_dependencies }}"
 
 - name: Create node user
   user: name={{statsd_user}} state=present shell=/bin/false system=yes

--- a/tasks/statsd.yml
+++ b/tasks/statsd.yml
@@ -23,9 +23,16 @@
 
 - name: Configure upstart
   template: src=upstart.conf.j2 dest=/etc/init/{{statsd_title}}.conf
-  when: ansible_distribution=="Ubuntu"
+  when: ansible_distribution=="Ubuntu" and ansible_distribution_major_version < "15.04"
   notify:
   - "{{statsd_title}} restart"
+
+- name: Configure systemd
+  template: src=systemd.service.j2 dest=/etc/systemd/system/{{statsd_title}}.service
+  when: ansible_distribution=="Ubuntu" and ansible_distribution_major_version > "15.04"
+  notify:
+  - "{{statsd_title}} restart"
+
 
 - name: Configure sysvinit
   template: src=sysvinit.conf.j2 dest=/etc/init.d/{{statsd_title}}

--- a/tasks/statsd.yml
+++ b/tasks/statsd.yml
@@ -1,8 +1,13 @@
 ---
 
+- shell: dpkg-query -W 'npm'
+  ignore_errors: True
+  register: has_npm
+
 - name: Ensure that NPM is installed
   apt:  name=npm update_cache=yes
-  
+  when: has_npm|failed
+
 - name: Prepare Statsd directory
   file: state=directory path={{statsd_home}}
 


### PR DESCRIPTION
* Adds support for out of role configuration of npm/nodejs, previously the 
* Conditionally chooses between upstart of systemd depending on major/minor ubuntu version, previously restart statsd at end of playbook would fail on ubuntu > 15.04
* Addresses malformed reference to with_items causing attempts to install 'statsd_extra_dependencies' package when no extra dependencies are specified