### PR TITLE
Add some improvements

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 
-- include: statsd.yml
+- include_tasks: statsd.yml
   when: statsd_enabled
   tags: [statsd]

--- a/tasks/statsd.yml
+++ b/tasks/statsd.yml
@@ -1,8 +1,13 @@
 ---
 
+- name: Check if npm is already installed
+  stat: path=/usr/bin/npm
+  register: check_npm_installed
+
 - name: Ensure that NPM is installed
   apt:  name=npm update_cache=yes
-  
+  when: check_npm_installed.stat.exists == False
+
 - name: Prepare Statsd directory
   file: state=directory path={{statsd_home}}
 
@@ -11,14 +16,14 @@
 
 - name: Install extra NPM dependencies
   npm: name={{item}} path={{statsd_home}}
-  with_items: statsd_extra_dependencies
+  with_items: "{{ statsd_extra_dependencies }}"
 
 - name: Create node user
   user: name={{statsd_user}} state=present shell=/bin/false system=yes
 
 - name: Configure upstart
   template: src=upstart.conf.j2 dest=/etc/init/{{statsd_title}}.conf
-  when: ansible_distribution=="Ubuntu"
+  when: ansible_distribution=="Ubuntu" and ansible_distribution_major_version < 15
   notify:
   - "{{statsd_title}} restart"
 
@@ -30,7 +35,8 @@
 
 - name: Configure systemd
   template: src=systemd.service.j2 dest=/etc/systemd/system/{{statsd_title}}.service
-  when: ansible_distribution=="Debian" and ansible_distribution_major_version > 8
+  when: (ansible_distribution=="Debian" and ansible_distribution_major_version > 8)
+        or (ansible_distribution=="Ubuntu" and ansible_distribution_major_version > 15)
   notify:
   - "{{statsd_title}} restart"
 

--- a/tasks/statsd.yml
+++ b/tasks/statsd.yml
@@ -23,7 +23,7 @@
 
 - name: Configure upstart
   template: src=upstart.conf.j2 dest=/etc/init/{{statsd_title}}.conf
-  when: ansible_distribution=="Ubuntu" and ansible_distribution_major_version < 15
+  when: ansible_distribution=="Ubuntu" and ansible_distribution_major_version is version_compare('15', '>=')
   notify:
   - "{{statsd_title}} restart"
 


### PR DESCRIPTION
Add some improvements:
  - Check if npm is already installed and don't try to do it if so
  - Fix systemd/upstart service configuration for Ubuntu <16.04 and >=16.04
  - Use new call 'include_tasks' instead of include to avoid warnings with Ansible >=2.4
